### PR TITLE
Add systemd boot timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # yeah, don't set my custom file
 config.ini
 
+# Don't save VSCode files
+*.code-workspace
+
 # C extensions
 *.so
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ config.ini
 
 # Don't save VSCode files
 *.code-workspace
+.vscode
 
 # C extensions
 *.so

--- a/README-SPI.md
+++ b/README-SPI.md
@@ -232,13 +232,13 @@ By default the **isp-lightning.service** file indicates that the script should b
 Now that the 'daemon' user is configured to allow access the hardware you can setup the script to be run as a system service as follows:
 
  ```shell
-   sudo ln -s /opt/ISP-RPi-mqtt-daemon/isp-lightning.service /etc/systemd/system/isp-lightning.service
+   sudo ln -sv /opt/ISP-lightning-mqtt-daemon/isp-lightning.{service,timer} /etc/systemd/system/
 
    sudo systemctl daemon-reload
 
-   # configure services so they start on reboot
+   # configure service and timer so they start on reboot
    sudo systemctl enable pigpiod.service
-   sudo systemctl enable isp-lightning.service
+   sudo systemctl enable isp-lightning.timer
 
    # start services now
    sudo systemctl start pigpiod.service

--- a/README.md
+++ b/README.md
@@ -234,13 +234,13 @@ By default the **isp-lightning.service** file indicates that the script should b
 Now that the 'daemon' user is configured to allow access the hardware you can setup the script to be run as a system service as follows:
 
  ```shell
-   sudo ln -s /opt/ISP-lightning-mqtt-daemon/isp-lightning.service /etc/systemd/system/isp-lightning.service
+   sudo ln -sv /opt/ISP-lightning-mqtt-daemon/isp-lightning.{service,timer} /etc/systemd/system/
 
    sudo systemctl daemon-reload
 
-   # configure services so they start on reboot
+   # configure service and timer so they start on reboot
    sudo systemctl enable pigpiod.service
-   sudo systemctl enable isp-lightning.service
+   sudo systemctl enable isp-lightning.timer
 
    # start services now
    sudo systemctl start pigpiod.service

--- a/isp-lightning.service
+++ b/isp-lightning.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=ISP AS3935 Lightning Detector MQTT Client/Daemon
 Documentation=https://github.com/ironsheep/lightning-detector-MQTT2HA-Daemon
-After=network.target mosquitto.service
+Wants=network-online.target
+After=network.target network-online.target mosquitto.service
 
 [Service]
 Type=notify
@@ -16,5 +17,6 @@ StandardError=journal
 Environment=PYTHONUNBUFFERED=1
 Restart=always
 
-[Install]
-WantedBy=multi-user.target
+### Removed Install since the Timer is being installed.
+#[Install]
+#WantedBy=multi-user.target

--- a/isp-lightning.timer
+++ b/isp-lightning.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Delay isp-lightning start on boot by 30 seconds
+
+[Timer]
+OnBootSec=30s
+Unit=isp-lightning.service
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
When someone is running the ISP-lightning-mqtt-daemon script on a RPi that is separate from the device that is running the MQTT server, there is currently nothing that prevents the script from starting on boot before the network is full initialized and capable of connecting to the MQTT server. This PR adds a 30 second timer that delays the script from starting too soon, and also adds a requirement for network-online.target so there's a valid IP before the script starts.

Also added VSCode config files to the .gitignore

Adds a README-SPI.md fix that was applied to README.md in c7f5aa47b6e628359106701f65af011f46e886f3, replacing `ISP-RPi-mqtt-daemon` with `ISP-lightning-mqtt-daemon`